### PR TITLE
Checking in changes prior to tagging of version 0.11.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension WebService-Toggl
 
 {{$NEXT}}
 
+0.11 2016-05-06T05:12:40Z
+
+    - add page parameters to details report (thanks, @mattgill!)
+
 0.10 2015-03-10T18:04:15Z
 
     - move test packages into their own files to appease Strawberry

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Fitz Elliott <felliott@fiskur.org>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.3.0, CPAN::Meta::Converter version 2.150001",
+   "generated_by" : "Minilla/v3.0.1, CPAN::Meta::Converter version 2.150001",
    "license" : [
       "perl_5"
    ],
@@ -79,5 +79,8 @@
          "web" : "https://github.com/felliott/WebService-Toggl"
       }
    },
-   "version" : "0.10"
+   "version" : "0.11",
+   "x_contributors" : [
+      "Matt Gill <code@mattgill.net>"
+   ]
 }

--- a/lib/WebService/Toggl.pm
+++ b/lib/WebService/Toggl.pm
@@ -6,7 +6,7 @@ use Moo;
 with 'WebService::Toggl::Role::Base';
 use namespace::clean;
 
-our $VERSION = "0.10";
+our $VERSION = "0.11";
 
 
 has 'me' => (is =>'ro', lazy => 1, builder => 1);


### PR DESCRIPTION
Changelog diff is:

diff --git a/Changes b/Changes
index ceda615..1061d5a 100644
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension WebService-Toggl

 {{$NEXT}}

+0.11 2016-05-06T05:12:40Z
+
+    - add page parameters to details report (thanks, @mattgill!)
+
 0.10 2015-03-10T18:04:15Z

     - move test packages into their own files to appease Strawberry